### PR TITLE
Backport the sigaltstack frame size checking fix

### DIFF
--- a/arch/riscv/kernel/signal.c
+++ b/arch/riscv/kernel/signal.c
@@ -309,13 +309,6 @@ static inline void __user *get_sigframe(struct ksignal *ksig,
 	/* Align the stack frame. */
 	sp &= ~0xfUL;
 
-	/*
-	 * Fail if the size of the altstack is not large enough for the
-	 * sigframe construction.
-	 */
-	if (current->sas_ss_size && sp < current->sas_ss_sp)
-		return (void __user __force *)-1UL;
-
 	return (void __user *)sp;
 }
 


### PR DESCRIPTION
It seems enough to address the problem I reported in [the forum](https://forum.banana-pi.org/t/the-futex-implementation-seems-to-have-problems/18059/4)